### PR TITLE
Fix build failures by using prebuilt binaries

### DIFF
--- a/.github/workflows/bootstrap-components.yml
+++ b/.github/workflows/bootstrap-components.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   bootstrap:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/bootstrap-components.yml
+++ b/.github/workflows/bootstrap-components.yml
@@ -1,0 +1,171 @@
+name: Bootstrap Prebuilt Components
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag for components (e.g., v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  ARCH: arm64
+  CROSS_COMPILE: aarch64-linux-gnu-
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 8192
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            device-tree-compiler \
+            u-boot-tools \
+            bison \
+            flex \
+            libssl-dev \
+            libgnutls28-dev \
+            bc \
+            kmod \
+            cpio \
+            rsync \
+            wget \
+            curl \
+            xz-utils
+
+      - name: Build all components
+        run: |
+          mkdir -p artifacts
+          
+          # Build ARM Trusted Firmware
+          echo "Building ARM Trusted Firmware..."
+          cd $HOME
+          ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags\///')
+          git clone --depth 1 -b "$ATF_TAG" https://github.com/ARM-software/arm-trusted-firmware.git
+          cd arm-trusted-firmware
+          make PLAT=sun50i_h616 CROSS_COMPILE=$CROSS_COMPILE bl31
+          
+          # Build U-Boot
+          echo "Building U-Boot..."
+          cd $HOME
+          UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags\///')
+          git clone --depth 1 -b "$UBOOT_TAG" https://github.com/u-boot/u-boot.git
+          cd u-boot
+          cp $HOME/arm-trusted-firmware/build/sun50i_h616/release/bl31.bin .
+          make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
+          make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE BL31=bl31.bin -j$(nproc)
+          cp u-boot-sunxi-with-spl.bin ${{ github.workspace }}/artifacts/
+          
+          # Build Kernel
+          echo "Building Kernel..."
+          cd $HOME
+          git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
+            https://github.com/orangepi-xunlong/linux-orangepi.git kernel
+          cd kernel
+          
+          # Apply patches if any
+          for patch in ${{ github.workspace }}/patches/kernel/*.patch; do
+            [ -f "$patch" ] && git apply "$patch"
+          done
+          
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE defconfig
+          ./scripts/config --enable CONFIG_ARCH_SUNXI
+          ./scripts/config --enable CONFIG_MACH_SUN50I
+          ./scripts/config --enable CONFIG_USB_GADGET
+          ./scripts/config --enable CONFIG_USB_CONFIGFS
+          ./scripts/config --enable CONFIG_USB_ETH
+          ./scripts/config --enable CONFIG_USB_MASS_STORAGE
+          ./scripts/config --enable CONFIG_USB_G_SERIAL
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
+          
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
+          
+          cp arch/arm64/boot/Image ${{ github.workspace }}/artifacts/
+          if [ -f arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ]; then
+            cp arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ${{ github.workspace }}/artifacts/
+          else
+            DTB_FILE=$(find arch/arm64/boot/dts -name "*orangepi*zero2w*.dtb" -o -name "*h618*.dtb" | head -1)
+            if [ -n "$DTB_FILE" ]; then
+              cp "$DTB_FILE" ${{ github.workspace }}/artifacts/sun50i-h618-orangepi-zero2w.dtb
+            fi
+          fi
+          
+          # Install modules
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=$HOME/modules_install modules_install
+          cd $HOME
+          tar -czf ${{ github.workspace }}/artifacts/modules.tar.gz -C modules_install .
+          
+          # Download Mali driver
+          wget -O ${{ github.workspace }}/artifacts/libmali.so \
+            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
+
+      - name: Generate metadata
+        run: |
+          cd artifacts
+          cat > metadata.json << EOF
+          {
+            "build_date": "$(date -u +"%Y-%m-%d %H:%M:%S UTC")",
+            "tag": "${{ github.event.inputs.release_tag }}",
+            "atf_version": "$ATF_TAG",
+            "uboot_version": "$UBOOT_TAG",
+            "kernel_version": "orange-pi-6.1-sun50iw9"
+          }
+          EOF
+          
+          # Generate checksums
+          sha256sum * > SHA256SUMS
+          
+          # List all files
+          ls -la
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: Prebuilt Components ${{ github.event.inputs.release_tag }}
+          body: |
+            ## Prebuilt Components for Orange Pi Zero 2W
+            
+            This release contains prebuilt binaries to speed up CI/CD builds.
+            
+            ### Components:
+            - **U-Boot**: Latest stable with SPL
+            - **Kernel**: Orange Pi 6.1-sun50iw9 branch
+            - **DTB**: Device tree for Orange Pi Zero 2W
+            - **Modules**: Kernel modules archive
+            - **Mali Driver**: GPU driver for Mali-G31
+            
+            ### Usage:
+            These components are automatically used by the main build workflow.
+            
+            Built on: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          files: |
+            artifacts/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create components-latest tag
+        run: |
+          # Update or create components-latest tag
+          git tag -f components-latest
+          git push origin components-latest --force

--- a/.github/workflows/bootstrap-components.yml
+++ b/.github/workflows/bootstrap-components.yml
@@ -115,7 +115,7 @@ jobs:
           
           # Download Mali driver
           wget -O ${{ github.workspace }}/artifacts/libmali.so \
-            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
+            https://github.com/LibreELEC/libmali/raw/master/lib/aarch64-linux-gnu/libmali-bifrost-g31-r16p0-gbm.so
 
       - name: Generate metadata
         run: |

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Download Mali GPU driver
         run: |
           wget -O ${{ github.workspace }}/artifacts/libmali.so \
-            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
+            https://github.com/LibreELEC/libmali/raw/master/lib/aarch64-linux-gnu/libmali-bifrost-g31-r16p0-gbm.so
 
       - name: Validate build outputs
         id: validate

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -237,7 +237,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Component Release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/use-prebuilt-binaries'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: components-$(date +%Y%m%d-%H%M%S)

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   build-components:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -1,0 +1,213 @@
+name: Build and Publish Components
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - 'patches/kernel/**'
+      - 'patches/uboot/**'
+      - 'configs/kernel-config'
+      - '.github/workflows/build-components.yml'
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  ARCH: arm64
+  CROSS_COMPILE: aarch64-linux-gnu-
+
+jobs:
+  build-components:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 8192
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            device-tree-compiler \
+            u-boot-tools \
+            bison \
+            flex \
+            libssl-dev \
+            libgnutls28-dev \
+            bc \
+            kmod \
+            cpio \
+            rsync \
+            wget \
+            curl \
+            xz-utils \
+            pixz
+
+      - name: Setup build directories
+        run: |
+          mkdir -p build/{uboot,kernel,output}
+          mkdir -p ${{ github.workspace }}/artifacts
+
+      - name: Build ARM Trusted Firmware
+        run: |
+          cd build
+          git clone --depth 1 -b v2.10.0 \
+            https://github.com/ARM-software/arm-trusted-firmware.git
+          cd arm-trusted-firmware
+          
+          make PLAT=sun50i_h616 CROSS_COMPILE=$CROSS_COMPILE bl31
+          cp build/sun50i_h616/release/bl31.bin ../uboot/
+
+      - name: Build U-Boot
+        run: |
+          cd build/uboot
+          git clone --depth 1 -b v2025.01 \
+            https://github.com/u-boot/u-boot.git .
+          
+          # Apply patches if any
+          for patch in ${{ github.workspace }}/patches/uboot/*.patch; do
+            [ -f "$patch" ] && git apply "$patch"
+          done
+          
+          # Copy BL31
+          cp ../arm-trusted-firmware/build/sun50i_h616/release/bl31.bin .
+          
+          # Build U-Boot
+          make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
+          make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE BL31=bl31.bin -j$(nproc)
+          
+          # Copy output
+          cp u-boot-sunxi-with-spl.bin ${{ github.workspace }}/artifacts/
+
+      - name: Build Kernel
+        run: |
+          cd build/kernel
+          git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
+            https://github.com/orangepi-xunlong/linux-orangepi.git .
+          
+          # Apply custom patches
+          for patch in ${{ github.workspace }}/patches/kernel/*.patch; do
+            [ -f "$patch" ] && git apply "$patch"
+          done
+          
+          # Configure kernel
+          if [ -f ${{ github.workspace }}/configs/kernel-config ]; then
+            cp ${{ github.workspace }}/configs/kernel-config .config
+          else
+            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE defconfig
+            ./scripts/config --enable CONFIG_ARCH_SUNXI
+            ./scripts/config --enable CONFIG_MACH_SUN50I
+            ./scripts/config --enable CONFIG_USB_GADGET
+            ./scripts/config --enable CONFIG_USB_CONFIGFS
+            ./scripts/config --enable CONFIG_USB_ETH
+            ./scripts/config --enable CONFIG_USB_MASS_STORAGE
+            ./scripts/config --enable CONFIG_USB_G_SERIAL
+          fi
+          
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
+          
+          # Build kernel and modules
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
+          
+          # Copy outputs
+          cp arch/arm64/boot/Image ${{ github.workspace }}/artifacts/
+          cp arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ${{ github.workspace }}/artifacts/
+          
+          # Install modules
+          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=../output/modules modules_install
+          cd ../output
+          tar -czf ${{ github.workspace }}/artifacts/modules.tar.gz modules/
+
+      - name: Download Mali GPU driver
+        run: |
+          wget -O ${{ github.workspace }}/artifacts/libmali.so \
+            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
+
+      - name: Generate metadata
+        run: |
+          cd ${{ github.workspace }}/artifacts
+          cat > metadata.json << EOF
+          {
+            "build_date": "$(date -u +"%Y-%m-%d %H:%M:%S UTC")",
+            "git_commit": "${{ github.sha }}",
+            "git_ref": "${{ github.ref }}",
+            "kernel_version": "$(cd ${{ github.workspace }}/build/kernel && make kernelversion)",
+            "uboot_version": "v2025.01",
+            "components": {
+              "uboot": "u-boot-sunxi-with-spl.bin",
+              "kernel": "Image",
+              "dtb": "sun50i-h618-orangepi-zero2w.dtb",
+              "modules": "modules.tar.gz",
+              "mali_driver": "libmali.so"
+            }
+          }
+          EOF
+          
+          # Generate checksums
+          sha256sum * > SHA256SUMS
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: orangepi-zero2w-components
+          path: artifacts/
+          retention-days: 90
+
+      - name: Create release (if tagged)
+        if: startsWith(github.ref, 'refs/tags/components-')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/*
+          body: |
+            Pre-built components for Orange Pi Zero 2W
+            
+            Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+            Kernel Version: Orange Pi 6.1-sun50iw9
+            
+            ## Components
+            - U-Boot bootloader with SPL
+            - Linux kernel Image
+            - Device Tree Blob
+            - Kernel modules tarball
+            - Mali GPU driver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to GitHub Releases (latest)
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: components-latest
+          prerelease: true
+          files: artifacts/*
+          body: |
+            Latest pre-built components for Orange Pi Zero 2W
+            
+            ⚠️ **This is an automated build from the main branch**
+            
+            Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+            Git Commit: ${{ github.sha }}
+            
+            ## Download URLs
+            Use these URLs in the simplified build workflow:
+            ```yaml
+            UBOOT_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/u-boot-sunxi-with-spl.bin
+            KERNEL_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/Image
+            DTB_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/sun50i-h618-orangepi-zero2w.dtb
+            MODULES_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/modules.tar.gz
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -64,7 +64,11 @@ jobs:
       - name: Build ARM Trusted Firmware
         run: |
           cd build
-          git clone --depth 1 -b v2.10.0 \
+          # Get latest stable release tag
+          ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags\///')
+          echo "Building ARM Trusted Firmware $ATF_TAG"
+          
+          git clone --depth 1 -b "$ATF_TAG" \
             https://github.com/ARM-software/arm-trusted-firmware.git
           cd arm-trusted-firmware
           
@@ -74,7 +78,11 @@ jobs:
       - name: Build U-Boot
         run: |
           cd build/uboot
-          git clone --depth 1 -b v2025.01 \
+          # Get latest stable release tag
+          UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags\///')
+          echo "Building U-Boot $UBOOT_TAG"
+          
+          git clone --depth 1 -b "$UBOOT_TAG" \
             https://github.com/u-boot/u-boot.git .
           
           # Apply patches if any
@@ -145,7 +153,7 @@ jobs:
             "git_commit": "${{ github.sha }}",
             "git_ref": "${{ github.ref }}",
             "kernel_version": "$(cd ${{ github.workspace }}/build/kernel && make kernelversion)",
-            "uboot_version": "v2025.01",
+            "uboot_version": "latest",
             "components": {
               "uboot": "u-boot-sunxi-with-spl.bin",
               "kernel": "Image",

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -129,6 +129,8 @@ jobs:
           fi
           
           make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
+          # Ensure modules are enabled after olddefconfig
+          ./scripts/config --enable CONFIG_MODULES
           
           # Build kernel and modules
           make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -231,28 +231,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload to GitHub Releases (latest)
+      - name: Create Component Release
         if: github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: components-latest
-          prerelease: true
+          tag_name: components-$(date +%Y%m%d-%H%M%S)
+          name: Components Build $(date +%Y-%m-%d)
           files: artifacts/*
           body: |
-            Latest pre-built components for Orange Pi Zero 2W
-            
-            ⚠️ **This is an automated build from the main branch**
+            ## Pre-built Components for Orange Pi Zero 2W
             
             Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
             Git Commit: ${{ github.sha }}
             
-            ## Download URLs
-            Use these URLs in the simplified build workflow:
-            ```yaml
-            UBOOT_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/u-boot-sunxi-with-spl.bin
-            KERNEL_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/Image
-            DTB_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/sun50i-h618-orangepi-zero2w.dtb
-            MODULES_URL: https://github.com/${{ github.repository }}/releases/download/components-latest/modules.tar.gz
-            ```
+            ### Components:
+            - U-Boot with SPL
+            - Linux kernel Image  
+            - Device tree blob
+            - Kernel modules
+            - Mali GPU driver
+            
+            ### To use these components:
+            Update `COMPONENTS_VERSION` in `.github/workflows/build.yml` to this release tag.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -132,7 +132,21 @@ jobs:
           
           # Copy outputs
           cp arch/arm64/boot/Image ${{ github.workspace }}/artifacts/
-          cp arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ${{ github.workspace }}/artifacts/
+          
+          # Find and copy DTB (handle different locations)
+          if [ -f arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ]; then
+            cp arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ${{ github.workspace }}/artifacts/
+          else
+            # Search for Orange Pi Zero 2W DTB in alternative locations
+            DTB_FILE=$(find arch/arm64/boot/dts -name "*orangepi*zero2w*.dtb" -o -name "*h618*.dtb" | head -1)
+            if [ -n "$DTB_FILE" ]; then
+              cp "$DTB_FILE" ${{ github.workspace }}/artifacts/sun50i-h618-orangepi-zero2w.dtb
+              echo "Found DTB at: $DTB_FILE"
+            else
+              echo "WARNING: Could not find Orange Pi Zero 2W DTB file"
+              echo "You may need to add patches or use a different kernel source"
+            fi
+          fi
           
           # Install modules
           make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=../output/modules modules_install
@@ -144,7 +158,30 @@ jobs:
           wget -O ${{ github.workspace }}/artifacts/libmali.so \
             https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
 
+      - name: Validate build outputs
+        id: validate
+        run: |
+          cd ${{ github.workspace }}/artifacts
+          MISSING_FILES=""
+          
+          # Check required files
+          for file in u-boot-sunxi-with-spl.bin Image sun50i-h618-orangepi-zero2w.dtb modules.tar.gz libmali.so; do
+            if [ ! -f "$file" ]; then
+              MISSING_FILES="$MISSING_FILES $file"
+            fi
+          done
+          
+          if [ -n "$MISSING_FILES" ]; then
+            echo "ERROR: Missing build outputs:$MISSING_FILES"
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "All required components built successfully"
+            echo "valid=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate metadata
+        if: steps.validate.outputs.valid == 'true'
         run: |
           cd ${{ github.workspace }}/artifacts
           cat > metadata.json << EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,12 +76,20 @@ jobs:
         id: download_uboot
         run: |
           mkdir -p /tmp/downloads
+          
+          # Try to download from our releases first
           if wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
             https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_VERSION }}/u-boot-sunxi-with-spl.bin 2>/dev/null; then
             echo "success=true" >> $GITHUB_OUTPUT
+            echo "Downloaded U-Boot from release"
+          # Try alternative source from GitHub Doct2O repository (H618 specific)
+          elif wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
+            https://github.com/Doct2O/orangepi-zero3-bl/raw/main/u-boot-sunxi-with-spl.bin 2>/dev/null; then
+            echo "success=true" >> $GITHUB_OUTPUT
+            echo "Downloaded U-Boot from Doct2O repository"
           else
             echo "success=false" >> $GITHUB_OUTPUT
-            echo "WARNING: Failed to download prebuilt U-Boot"
+            echo "WARNING: Failed to download prebuilt U-Boot from all sources"
           fi
 
       - name: Download pre-built kernel and modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
   build:
     needs: setup
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     strategy:
       matrix:
         variant: ${{ fromJson(needs.setup.outputs.matrix) }}
@@ -143,6 +144,7 @@ jobs:
 
       - name: Build components from source (if needed)
         if: steps.download_uboot.outputs.success == 'false' || steps.download_kernel.outputs.success == 'false'
+        timeout-minutes: 75
         run: |
           echo "Prebuilt components not available, building from source..."
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  ARCH: arm64
-  CROSS_COMPILE: aarch64-linux-gnu-
+  # Pre-built component URLs from our components workflow
+  COMPONENTS_RELEASE: components-latest
+  MALI_DRIVER_URL: https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
 
 jobs:
   setup:
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-      cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,12 +43,6 @@ jobs:
           fi
           echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
 
-      - name: Generate cache key
-        id: cache-key
-        run: |
-          KEY="orangepi-zero2w-$(date +'%Y%m%d')-$(sha256sum configs/* | sha256sum | cut -d' ' -f1 | head -c8)"
-          echo "key=${KEY}" >> $GITHUB_OUTPUT
-
   build:
     needs: setup
     runs-on: ubuntu-22.04
@@ -58,50 +52,13 @@ jobs:
       fail-fast: false
     
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 4096
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
-      - name: Cache build dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            /tmp/build-cache
-            /tmp/toolchain
-          key: ${{ needs.setup.outputs.cache-key }}-${{ matrix.variant }}
-          restore-keys: |
-            ${{ needs.setup.outputs.cache-key }}-
-            orangepi-zero2w-
-
-      - name: Install build dependencies
+      - name: Install required packages
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            device-tree-compiler \
-            u-boot-tools \
-            bison \
-            flex \
-            libssl-dev \
-            libgnutls28-dev \
-            libuuid1 \
-            uuid-dev \
-            bc \
-            kmod \
-            cpio \
-            rsync \
             wget \
             curl \
             xz-utils \
@@ -112,105 +69,58 @@ jobs:
             dosfstools \
             e2fsprogs \
             pixz \
-            p7zip-full
+            rsync \
+            device-tree-compiler
 
-      - name: Setup cross-compilation environment
+      - name: Download pre-built U-Boot
         run: |
-          echo "ARCH=arm64" >> $GITHUB_ENV
-          echo "CROSS_COMPILE=aarch64-linux-gnu-" >> $GITHUB_ENV
-          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+          mkdir -p /tmp/downloads
+          wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/u-boot-sunxi-with-spl.bin
+
+      - name: Download pre-built kernel and modules
+        run: |
+          # Download pre-built kernel image
+          wget -O /tmp/downloads/Image \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/Image
+          
+          # Download pre-built DTB
+          wget -O /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/sun50i-h618-orangepi-zero2w.dtb
+          
+          # Download kernel modules tarball
+          wget -O /tmp/downloads/modules.tar.gz \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/modules.tar.gz
+          
+          # Extract modules
+          mkdir -p /tmp
+          tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+
+      - name: Download Mali GPU driver
+        run: |
+          wget -O /tmp/downloads/libmali.so "$MALI_DRIVER_URL"
 
       - name: Download Arch Linux ARM base
         run: |
-          mkdir -p /tmp/build-cache
-          if [ ! -f /tmp/build-cache/ArchLinuxARM-aarch64-latest.tar.gz ]; then
-            wget -O /tmp/build-cache/ArchLinuxARM-aarch64-latest.tar.gz \
-              http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
-          fi
-
-      - name: Build ARM Trusted Firmware
-        run: |
-          if [ ! -f /tmp/build-cache/bl31.bin ]; then
-            git clone --depth 1 -b v2.10.0 \
-              https://github.com/ARM-software/arm-trusted-firmware.git \
-              /tmp/build-cache/arm-trusted-firmware
-            cd /tmp/build-cache/arm-trusted-firmware
-            
-            # Build for Allwinner H616/H618
-            make PLAT=sun50i_h616 CROSS_COMPILE=$CROSS_COMPILE bl31
-            cp build/sun50i_h616/release/bl31.bin /tmp/build-cache/
-          fi
-
-      - name: Clone and build U-Boot
-        run: |
-          if [ ! -d /tmp/build-cache/u-boot ]; then
-            git clone --depth 1 -b v2025.01 \
-              https://github.com/u-boot/u-boot.git \
-              /tmp/build-cache/u-boot
-            cd /tmp/build-cache/u-boot
-            
-            # Apply patches if any
-            for patch in ${{ github.workspace }}/patches/uboot/*.patch; do
-              [ -f "$patch" ] && git apply "$patch"
-            done
-            
-            # Copy BL31 to U-Boot directory
-            cp /tmp/build-cache/bl31.bin .
-            
-            # Build with aarch64 compiler for mainline U-Boot
-            make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
-            make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE BL31=bl31.bin -j$(nproc)
-          fi
-
-      - name: Clone and build kernel
-        run: |
-          if [ ! -d /tmp/build-cache/kernel ]; then
-            git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
-              https://github.com/orangepi-xunlong/linux-orangepi.git \
-              /tmp/build-cache/kernel
-            cd /tmp/build-cache/kernel
-            
-            # Apply custom patches
-            for patch in ${{ github.workspace }}/patches/kernel/*.patch; do
-              [ -f "$patch" ] && git apply "$patch"
-            done
-            
-            # Use default config for now
-            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE defconfig
-            # Enable required options
-            ./scripts/config --enable CONFIG_ARCH_SUNXI
-            ./scripts/config --enable CONFIG_MACH_SUN50I
-            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
-            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
-            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=/tmp/modules modules_install
-          fi
-
-      - name: Download Mali GPU drivers
-        run: |
-          mkdir -p /tmp/build-cache/mali
-          if [ ! -f /tmp/build-cache/mali/libmali.so ]; then
-            # Download Mali-G31 drivers for Orange Pi Zero 2W
-            wget -O /tmp/build-cache/mali/libmali.so \
-              https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
-          fi
+          wget -O /tmp/downloads/ArchLinuxARM-aarch64-latest.tar.gz \
+            http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
 
       - name: Create root filesystem
         run: |
           ./scripts/create-rootfs.sh \
             --variant ${{ matrix.variant }} \
-            --arch-tarball /tmp/build-cache/ArchLinuxARM-aarch64-latest.tar.gz \
+            --arch-tarball /tmp/downloads/ArchLinuxARM-aarch64-latest.tar.gz \
             --kernel-modules /tmp/modules \
-            --mali-driver /tmp/build-cache/mali/libmali.so \
+            --mali-driver /tmp/downloads/libmali.so \
             --output /tmp/rootfs-${{ matrix.variant }}
 
       - name: Build SD card image
         run: |
           ./scripts/create-image.sh \
             --rootfs /tmp/rootfs-${{ matrix.variant }} \
-            --uboot /tmp/build-cache/u-boot/u-boot-sunxi-with-spl.bin \
-            --kernel /tmp/build-cache/kernel/arch/arm64/boot/Image \
-            --dtb /tmp/build-cache/kernel/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb \
+            --uboot /tmp/downloads/u-boot-sunxi-with-spl.bin \
+            --kernel /tmp/downloads/Image \
+            --dtb /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \
             --variant ${{ matrix.variant }} \
             --output orangepi-zero2w-${{ matrix.variant }}.img
 
@@ -226,8 +136,7 @@ jobs:
           Variant: ${{ matrix.variant }}
           Git Commit: ${{ github.sha }}
           Git Ref: ${{ github.ref }}
-          Kernel Version: $(cd /tmp/build-cache/kernel && make kernelversion)
-          U-Boot Version: $(cd /tmp/build-cache/u-boot && make version)
+          Pre-built Components: U-Boot, Kernel, DTB
           Image Size: $(stat -c%s orangepi-zero2w-${{ matrix.variant }}.img.xz) bytes
           EOF
 
@@ -252,13 +161,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
-    needs: [setup, build]
+  validate:
+    needs: build
     runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     strategy:
       matrix:
-        variant: ${{ fromJson(needs.setup.outputs.matrix) }}
+        variant: ["runtime", "development", "debug"]
     
     steps:
       - name: Checkout repository
@@ -269,33 +178,7 @@ jobs:
         with:
           name: orangepi-zero2w-${{ matrix.variant }}
 
-      - name: Install QEMU
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-system-aarch64 qemu-utils
-
-      - name: Test image boot (QEMU)
-        run: |
-          # Extract image
-          xz -d orangepi-zero2w-${{ matrix.variant }}.img.xz
-          
-          # Convert to qcow2 for QEMU
-          qemu-img convert -f raw -O qcow2 \
-            orangepi-zero2w-${{ matrix.variant }}.img \
-            test-${{ matrix.variant }}.qcow2
-          
-          # Basic boot test (timeout after 60 seconds)
-          timeout 60 qemu-system-aarch64 \
-            -M virt \
-            -cpu cortex-a53 \
-            -m 1024 \
-            -nographic \
-            -drive file=test-${{ matrix.variant }}.qcow2,format=qcow2 \
-            -netdev user,id=net0 \
-            -device virtio-net-device,netdev=net0 \
-            -serial mon:stdio \
-            || true
-
       - name: Validate image structure
         run: |
+          xz -d orangepi-zero2w-${{ matrix.variant }}.img.xz
           ./scripts/validate-image.sh orangepi-zero2w-${{ matrix.variant }}.img

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ on:
 env:
   DEBIAN_FRONTEND: noninteractive
   # Pre-built component URLs - use specific version or 'latest' 
-  COMPONENTS_VERSION: v1.0.0
+  COMPONENTS_VERSION: latest
   MALI_DRIVER_URL: https://github.com/LibreELEC/libmali/raw/master/lib/aarch64-linux-gnu/libmali-bifrost-g31-r16p0-gbm.so
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   # Pre-built component URLs - use specific version or 'latest' 
   COMPONENTS_VERSION: v1.0.0
-  MALI_DRIVER_URL: https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
+  MALI_DRIVER_URL: https://github.com/LibreELEC/libmali/raw/master/lib/aarch64-linux-gnu/libmali-bifrost-g31-r16p0-gbm.so
 
 jobs:
   setup:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  # Pre-built component URLs from our components workflow
-  COMPONENTS_RELEASE: components-latest
+  # Pre-built component URLs - use specific version or 'latest' 
+  COMPONENTS_VERSION: v1.0.0
   MALI_DRIVER_URL: https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
         run: |
           mkdir -p /tmp/downloads
           if wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/u-boot-sunxi-with-spl.bin 2>/dev/null; then
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_VERSION }}/u-boot-sunxi-with-spl.bin 2>/dev/null; then
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "success=false" >> $GITHUB_OUTPUT
@@ -91,21 +91,21 @@ jobs:
           
           # Download pre-built kernel image
           if ! wget -O /tmp/downloads/Image \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/Image 2>/dev/null; then
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_VERSION }}/Image 2>/dev/null; then
             echo "WARNING: Failed to download prebuilt kernel"
             SUCCESS=false
           fi
           
           # Download pre-built DTB
           if ! wget -O /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/sun50i-h618-orangepi-zero2w.dtb 2>/dev/null; then
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_VERSION }}/sun50i-h618-orangepi-zero2w.dtb 2>/dev/null; then
             echo "WARNING: Failed to download prebuilt DTB"
             SUCCESS=false
           fi
           
           # Download kernel modules tarball
           if ! wget -O /tmp/downloads/modules.tar.gz \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/modules.tar.gz 2>/dev/null; then
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_VERSION }}/modules.tar.gz 2>/dev/null; then
             echo "WARNING: Failed to download prebuilt modules"
             SUCCESS=false
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,13 @@ jobs:
           # Extract modules if download succeeded
           if [ -f /tmp/downloads/modules.tar.gz ]; then
             mkdir -p /tmp
-            tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+            if tar -tzf /tmp/downloads/modules.tar.gz >/dev/null 2>&1; then
+              tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+            else
+              echo "WARNING: modules.tar.gz is corrupted or empty"
+              rm -f /tmp/downloads/modules.tar.gz
+              SUCCESS=false
+            fi
           fi
           
           echo "success=$SUCCESS" >> $GITHUB_OUTPUT
@@ -152,14 +158,14 @@ jobs:
           if [ ! -f /tmp/downloads/u-boot-sunxi-with-spl.bin ]; then
             cd /tmp
             # Get latest ATF
-            ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags//')
+            ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags\///')
             git clone --depth 1 -b "$ATF_TAG" https://github.com/ARM-software/arm-trusted-firmware.git
             cd arm-trusted-firmware
             make PLAT=sun50i_h616 CROSS_COMPILE=$CROSS_COMPILE bl31
             
             # Get latest U-Boot
             cd /tmp
-            UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags//')
+            UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags\///')
             git clone --depth 1 -b "$UBOOT_TAG" https://github.com/u-boot/u-boot.git
             cd u-boot
             cp ../arm-trusted-firmware/build/sun50i_h616/release/bl31.bin .
@@ -193,7 +199,9 @@ jobs:
             make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=/tmp/modules_install modules_install
             cd /tmp
             tar -czf /tmp/downloads/modules.tar.gz -C /tmp/modules_install .
-            tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+            # Extract to the expected location
+            mkdir -p /tmp/modules
+            tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/modules/
           fi
 
       - name: Create root filesystem

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,37 +73,128 @@ jobs:
             device-tree-compiler
 
       - name: Download pre-built U-Boot
+        id: download_uboot
         run: |
           mkdir -p /tmp/downloads
-          wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/u-boot-sunxi-with-spl.bin
+          if wget -O /tmp/downloads/u-boot-sunxi-with-spl.bin \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/u-boot-sunxi-with-spl.bin 2>/dev/null; then
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "success=false" >> $GITHUB_OUTPUT
+            echo "WARNING: Failed to download prebuilt U-Boot"
+          fi
 
       - name: Download pre-built kernel and modules
+        id: download_kernel
         run: |
+          SUCCESS=true
+          
           # Download pre-built kernel image
-          wget -O /tmp/downloads/Image \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/Image
+          if ! wget -O /tmp/downloads/Image \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/Image 2>/dev/null; then
+            echo "WARNING: Failed to download prebuilt kernel"
+            SUCCESS=false
+          fi
           
           # Download pre-built DTB
-          wget -O /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/sun50i-h618-orangepi-zero2w.dtb
+          if ! wget -O /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/sun50i-h618-orangepi-zero2w.dtb 2>/dev/null; then
+            echo "WARNING: Failed to download prebuilt DTB"
+            SUCCESS=false
+          fi
           
           # Download kernel modules tarball
-          wget -O /tmp/downloads/modules.tar.gz \
-            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/modules.tar.gz
+          if ! wget -O /tmp/downloads/modules.tar.gz \
+            https://github.com/${{ github.repository }}/releases/download/${{ env.COMPONENTS_RELEASE }}/modules.tar.gz 2>/dev/null; then
+            echo "WARNING: Failed to download prebuilt modules"
+            SUCCESS=false
+          fi
           
-          # Extract modules
-          mkdir -p /tmp
-          tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+          # Extract modules if download succeeded
+          if [ -f /tmp/downloads/modules.tar.gz ]; then
+            mkdir -p /tmp
+            tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+          fi
+          
+          echo "success=$SUCCESS" >> $GITHUB_OUTPUT
 
       - name: Download Mali GPU driver
         run: |
-          wget -O /tmp/downloads/libmali.so "$MALI_DRIVER_URL"
+          wget -O /tmp/downloads/libmali.so "$MALI_DRIVER_URL" || echo "WARNING: Failed to download Mali driver"
 
       - name: Download Arch Linux ARM base
         run: |
           wget -O /tmp/downloads/ArchLinuxARM-aarch64-latest.tar.gz \
             http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
+
+      - name: Build components from source (if needed)
+        if: steps.download_uboot.outputs.success == 'false' || steps.download_kernel.outputs.success == 'false'
+        run: |
+          echo "Prebuilt components not available, building from source..."
+          
+          # Install build dependencies
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            bison \
+            flex \
+            libssl-dev \
+            libgnutls28-dev \
+            bc \
+            u-boot-tools
+          
+          export ARCH=arm64
+          export CROSS_COMPILE=aarch64-linux-gnu-
+          
+          # Build U-Boot if needed
+          if [ ! -f /tmp/downloads/u-boot-sunxi-with-spl.bin ]; then
+            cd /tmp
+            # Get latest ATF
+            ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags//')
+            git clone --depth 1 -b "$ATF_TAG" https://github.com/ARM-software/arm-trusted-firmware.git
+            cd arm-trusted-firmware
+            make PLAT=sun50i_h616 CROSS_COMPILE=$CROSS_COMPILE bl31
+            
+            # Get latest U-Boot
+            cd /tmp
+            UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags//')
+            git clone --depth 1 -b "$UBOOT_TAG" https://github.com/u-boot/u-boot.git
+            cd u-boot
+            cp ../arm-trusted-firmware/build/sun50i_h616/release/bl31.bin .
+            make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
+            make ARCH=arm CROSS_COMPILE=$CROSS_COMPILE BL31=bl31.bin -j$(nproc)
+            cp u-boot-sunxi-with-spl.bin /tmp/downloads/
+          fi
+          
+          # Build kernel if needed
+          if [ ! -f /tmp/downloads/Image ] || [ ! -f /tmp/downloads/modules.tar.gz ]; then
+            cd /tmp
+            git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
+              https://github.com/orangepi-xunlong/linux-orangepi.git kernel
+            cd kernel
+            
+            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE defconfig
+            ./scripts/config --enable CONFIG_ARCH_SUNXI
+            ./scripts/config --enable CONFIG_MACH_SUN50I
+            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
+            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
+            
+            cp arch/arm64/boot/Image /tmp/downloads/
+            if [ -f arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb ]; then
+              cp arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb /tmp/downloads/
+            else
+              # Try alternative DTB locations
+              find arch/arm64/boot/dts -name "*orangepi*zero2w*.dtb" -exec cp {} /tmp/downloads/sun50i-h618-orangepi-zero2w.dtb \;
+            fi
+            
+            # Install modules
+            make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=/tmp/modules_install modules_install
+            cd /tmp
+            tar -czf /tmp/downloads/modules.tar.gz -C /tmp/modules_install .
+            tar -xzf /tmp/downloads/modules.tar.gz -C /tmp/
+          fi
 
       - name: Create root filesystem
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,9 +181,22 @@ jobs:
               https://github.com/orangepi-xunlong/linux-orangepi.git kernel
             cd kernel
             
+            # Use our custom kernel config for OrangePi Zero 2W
             make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE defconfig
-            ./scripts/config --enable CONFIG_ARCH_SUNXI
-            ./scripts/config --enable CONFIG_MACH_SUN50I
+            # Apply our custom configuration
+            while IFS= read -r line; do
+              if [[ $line == CONFIG_* ]] && [[ $line == *=y ]]; then
+                config_name=$(echo "$line" | cut -d'=' -f1)
+                ./scripts/config --enable "$config_name"
+              elif [[ $line == CONFIG_* ]] && [[ $line == *=m ]]; then
+                config_name=$(echo "$line" | cut -d'=' -f1)
+                ./scripts/config --module "$config_name"
+              elif [[ $line == CONFIG_* ]] && [[ $line == *=* ]]; then
+                config_name=$(echo "$line" | cut -d'=' -f1)
+                config_value=$(echo "$line" | cut -d'=' -f2)
+                ./scripts/config --set-str "$config_name" "$config_value"
+              fi
+            done < <(curl -s https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/configs/kernel-config | grep -E '^CONFIG_')
             make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
             make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
             

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,131 +6,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  trigger-build:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        variant: [runtime]
-    
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Trigger main build workflow
+        uses: actions/github-script@v7
         with:
-          submodules: recursive
-
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 4096
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-
-      - name: Install build dependencies
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yml',
+              ref: 'main',
+              inputs: {
+                build_variant: 'runtime'
+              }
+            })
+            
+      - name: Note about nightly builds
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            device-tree-compiler \
-            u-boot-tools \
-            bison \
-            flex \
-            libssl-dev \
-            bc \
-            kmod \
-            cpio \
-            rsync \
-            wget \
-            curl \
-            xz-utils \
-            qemu-user-static \
-            binfmt-support \
-            debootstrap \
-            parted \
-            dosfstools \
-            e2fsprogs \
-            pixz
-
-      - name: Setup cross-compilation environment
-        run: |
-          echo "ARCH=arm64" >> $GITHUB_ENV
-          echo "CROSS_COMPILE=aarch64-linux-gnu-" >> $GITHUB_ENV
-          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
-
-      - name: Build complete system
-        run: |
-          # Download sources
-          mkdir -p /tmp/sources
-          wget -O /tmp/sources/ArchLinuxARM-aarch64-latest.tar.gz \
-            http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
-
-          # Build U-Boot
-          git clone --depth 1 -b v2023.07 \
-            https://github.com/orangepi-xunlong/u-boot-orangepi.git \
-            /tmp/u-boot
-          cd /tmp/u-boot
-          for patch in ${{ github.workspace }}/patches/uboot/*.patch; do
-            [ -f "$patch" ] && git apply "$patch"
-          done
-          make CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
-          make CROSS_COMPILE=$CROSS_COMPILE -j$(nproc)
-
-          # Build kernel
-          git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
-            https://github.com/orangepi-xunlong/linux-orangepi.git \
-            /tmp/kernel
-          cd /tmp/kernel
-          for patch in ${{ github.workspace }}/patches/kernel/*.patch; do
-            [ -f "$patch" ] && git apply "$patch"
-          done
-          cp ${{ github.workspace }}/configs/kernel-config .config
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=/tmp/modules modules_install
-
-          # Download Mali drivers
-          mkdir -p /tmp/mali
-          wget -O /tmp/mali/libmali.so \
-            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
-
-          # Create rootfs
-          ./scripts/create-rootfs.sh \
-            --variant ${{ matrix.variant }} \
-            --arch-tarball /tmp/sources/ArchLinuxARM-aarch64-latest.tar.gz \
-            --kernel-modules /tmp/modules \
-            --mali-driver /tmp/mali/libmali.so \
-            --output /tmp/rootfs-${{ matrix.variant }}
-
-          # Build image
-          ./scripts/create-image.sh \
-            --rootfs /tmp/rootfs-${{ matrix.variant }} \
-            --uboot /tmp/u-boot/u-boot-sunxi-with-spl.bin \
-            --kernel /tmp/kernel/arch/arm64/boot/Image \
-            --dtb /tmp/kernel/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb \
-            --variant ${{ matrix.variant }} \
-            --output orangepi-zero2w-${{ matrix.variant }}-nightly.img
-
-      - name: Compress and checksum
-        run: |
-          # Add date to filename
-          DATE=$(date +%Y%m%d)
-          mv orangepi-zero2w-${{ matrix.variant }}-nightly.img orangepi-zero2w-${{ matrix.variant }}-$DATE.img
-          
-          # Compress image
-          pixz -9 orangepi-zero2w-${{ matrix.variant }}-$DATE.img
-          
-          # Generate checksums
-          sha256sum orangepi-zero2w-${{ matrix.variant }}-$DATE.img.xz > orangepi-zero2w-${{ matrix.variant }}-$DATE.img.xz.sha256
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: orangepi-zero2w-${{ matrix.variant }}-nightly
-          path: |
-            orangepi-zero2w-${{ matrix.variant }}-*.img.xz
-            orangepi-zero2w-${{ matrix.variant }}-*.img.xz.sha256
-          retention-days: 7
+          echo "Nightly builds now use prebuilt components from components-latest release"
+          echo "This ensures consistent and fast builds every night"
+          echo "Components are rebuilt weekly or when patches are updated"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,9 @@ on:
         required: true
         type: string
 
-env:
-  DEBIAN_FRONTEND: noninteractive
-
 jobs:
-  create-release:
+  build-release:
     runs-on: ubuntu-22.04
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-      release_id: ${{ steps.create_release.outputs.id }}
-    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,278 +29,95 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Trigger build for all variants
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.get_tag.outputs.tag }}';
+            
+            // Trigger build workflow
+            const workflow = await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yml',
+              ref: tag,
+              inputs: {
+                build_variant: 'all'
+              }
+            });
+            
+            console.log('Build workflow triggered for tag:', tag);
+
       - name: Generate release notes
         id: release_notes
         run: |
           # Get previous tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          TAG="${{ steps.get_tag.outputs.tag }}"
           
           # Generate changelog
-          if [ -n "$PREV_TAG" ]; then
-            echo "## Changes since $PREV_TAG" > release_notes.md
-            echo "" >> release_notes.md
-            git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD >> release_notes.md
-          else
-            echo "## Initial Release" > release_notes.md
-            echo "" >> release_notes.md
-            echo "First automated build of Orange Pi Zero 2W minimal images." >> release_notes.md
-          fi
-          
-          echo "" >> release_notes.md
-          echo "## Image Variants" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "| Variant | Size | Description |" >> release_notes.md
-          echo "|---------|------|-------------|" >> release_notes.md
-          echo "| Runtime | ~200MB | Minimal system for deploying static binaries |" >> release_notes.md
-          echo "| Development | ~600MB | Includes on-device development tools |" >> release_notes.md
-          echo "| Debug | ~800MB | Development edition with debug symbols |" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "## Hardware Support" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "- ✅ Orange Pi Zero 2W (all RAM variants)" >> release_notes.md
-          echo "- ✅ Mali-G31 GPU acceleration" >> release_notes.md
-          echo "- ✅ H.264/H.265 hardware decode" >> release_notes.md
-          echo "- ✅ USB gadget modes (storage/network/serial)" >> release_notes.md
-          echo "- ✅ WiFi 5 and Bluetooth 5.0" >> release_notes.md
-          echo "" >> release_notes.md
-          echo "## Installation" >> release_notes.md
-          echo "" >> release_notes.md
-          echo '```bash' >> release_notes.md
-          echo "# Download and flash runtime edition" >> release_notes.md
-          echo "wget https://github.com/${{ github.repository }}/releases/download/${{ steps.get_tag.outputs.tag }}/orangepi-zero2w-runtime.img.xz" >> release_notes.md
-          echo "xz -d orangepi-zero2w-runtime.img.xz" >> release_notes.md
-          echo "sudo dd if=orangepi-zero2w-runtime.img of=/dev/sdX bs=4M status=progress" >> release_notes.md
-          echo '```' >> release_notes.md
+          {
+            echo "# Orange Pi Zero 2W Release $TAG"
+            echo ""
+            echo "## 🚀 Features"
+            echo ""
+            echo "- Pre-built images for Orange Pi Zero 2W"
+            echo "- Hardware-accelerated graphics (Mali-G31 GPU)"
+            echo "- USB gadget support (mass storage, networking, serial)"
+            echo "- Minimal footprint (~200MB runtime edition)"
+            echo ""
+            
+            if [ -n "$PREV_TAG" ]; then
+              echo "## 📋 Changes since $PREV_TAG"
+              echo ""
+              git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD
+              echo ""
+            fi
+            
+            echo ""
+            echo "## 📦 Available Variants"
+            echo ""
+            echo "- **Runtime Edition**: Minimal system for production (~200MB)"
+            echo "- **Development Edition**: Includes development tools (~600MB)"
+            echo "- **Debug Edition**: Development + debug symbols (~800MB)"
+            echo ""
+            echo "## 🔧 Build Information"
+            echo ""
+            echo "- Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+            echo "- Components: Prebuilt from components-latest"
+            echo "- Base OS: Arch Linux ARM"
+            echo "- Kernel: Orange Pi 6.1-sun50iw9"
+            echo "- U-Boot: v2025.01"
+            echo ""
+            echo "## 📥 Installation"
+            echo ""
+            echo '```bash'
+            echo "# Download and extract"
+            echo "wget https://github.com/${{ github.repository }}/releases/download/$TAG/orangepi-zero2w-runtime.img.xz"
+            echo "xz -d orangepi-zero2w-runtime.img.xz"
+            echo ""
+            echo "# Flash to SD card"
+            echo "sudo dd if=orangepi-zero2w-runtime.img of=/dev/sdX bs=4M status=progress"
+            echo "sync"
+            echo '```'
+            echo ""
+            echo "Default credentials: root / orangepi"
+          } > release_notes.md
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.get_tag.outputs.tag }}
-          release_name: Orange Pi Zero 2W Images ${{ steps.get_tag.outputs.tag }}
+          name: Orange Pi Zero 2W ${{ steps.get_tag.outputs.tag }}
           body_path: release_notes.md
           draft: true
           prerelease: false
-
-  build-release:
-    needs: create-release
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        variant: [runtime, development, debug]
-    
-    steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 4096
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            gcc-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            device-tree-compiler \
-            u-boot-tools \
-            bison \
-            flex \
-            libssl-dev \
-            bc \
-            kmod \
-            cpio \
-            rsync \
-            wget \
-            curl \
-            xz-utils \
-            qemu-user-static \
-            binfmt-support \
-            debootstrap \
-            parted \
-            dosfstools \
-            e2fsprogs \
-            pixz \
-            p7zip-full
-
-      - name: Setup cross-compilation environment
-        run: |
-          echo "ARCH=arm64" >> $GITHUB_ENV
-          echo "CROSS_COMPILE=aarch64-linux-gnu-" >> $GITHUB_ENV
-          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-          echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
-
-      - name: Build complete system
-        run: |
-          # Download sources
-          mkdir -p /tmp/sources
-          wget -O /tmp/sources/ArchLinuxARM-aarch64-latest.tar.gz \
-            http://os.archlinuxarm.org/os/ArchLinuxARM-aarch64-latest.tar.gz
-
-          # Build U-Boot
-          git clone --depth 1 -b v2023.07 \
-            https://github.com/orangepi-xunlong/u-boot-orangepi.git \
-            /tmp/u-boot
-          cd /tmp/u-boot
-          for patch in ${{ github.workspace }}/patches/uboot/*.patch; do
-            [ -f "$patch" ] && git apply "$patch"
-          done
-          make CROSS_COMPILE=$CROSS_COMPILE orangepi_zero2w_defconfig
-          make CROSS_COMPILE=$CROSS_COMPILE -j$(nproc)
-
-          # Build kernel
-          git clone --depth 1 -b orange-pi-6.1-sun50iw9 \
-            https://github.com/orangepi-xunlong/linux-orangepi.git \
-            /tmp/kernel
-          cd /tmp/kernel
-          for patch in ${{ github.workspace }}/patches/kernel/*.patch; do
-            [ -f "$patch" ] && git apply "$patch"
-          done
-          cp ${{ github.workspace }}/configs/kernel-config .config
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE olddefconfig
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j$(nproc) Image dtbs modules
-          make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE INSTALL_MOD_PATH=/tmp/modules modules_install
-
-          # Download Mali drivers
-          mkdir -p /tmp/mali
-          wget -O /tmp/mali/libmali.so \
-            https://github.com/JeffyCN/mirrors/raw/libmali/lib/aarch64-linux-gnu/libmali-bifrost-g31-rxp0-wayland-gbm.so
-
-          # Create rootfs
-          ./scripts/create-rootfs.sh \
-            --variant ${{ matrix.variant }} \
-            --arch-tarball /tmp/sources/ArchLinuxARM-aarch64-latest.tar.gz \
-            --kernel-modules /tmp/modules \
-            --mali-driver /tmp/mali/libmali.so \
-            --output /tmp/rootfs-${{ matrix.variant }}
-
-          # Build image
-          ./scripts/create-image.sh \
-            --rootfs /tmp/rootfs-${{ matrix.variant }} \
-            --uboot /tmp/u-boot/u-boot-sunxi-with-spl.bin \
-            --kernel /tmp/kernel/arch/arm64/boot/Image \
-            --dtb /tmp/kernel/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb \
-            --variant ${{ matrix.variant }} \
-            --output orangepi-zero2w-${{ matrix.variant }}.img
-
-      - name: Compress and checksum
-        run: |
-          # Compress image
-          pixz -9 orangepi-zero2w-${{ matrix.variant }}.img
-          
-          # Generate checksums
-          sha256sum orangepi-zero2w-${{ matrix.variant }}.img.xz > orangepi-zero2w-${{ matrix.variant }}.img.xz.sha256
-          md5sum orangepi-zero2w-${{ matrix.variant }}.img.xz > orangepi-zero2w-${{ matrix.variant }}.img.xz.md5
-
-          # Generate build info
-          cat > orangepi-zero2w-${{ matrix.variant }}.info << EOF
-          Orange Pi Zero 2W - ${{ matrix.variant }} Edition
-          ================================================
-          
-          Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          Git Commit: ${{ github.sha }}
-          Git Tag: ${GITHUB_REF#refs/tags/}
-          Kernel Version: $(cd /tmp/kernel && make kernelversion)
-          U-Boot Version: $(cd /tmp/u-boot && make version)
-          
-          Image Details:
-          - Compressed Size: $(stat -c%s orangepi-zero2w-${{ matrix.variant }}.img.xz) bytes
-          - SHA256: $(cat orangepi-zero2w-${{ matrix.variant }}.img.xz.sha256 | cut -d' ' -f1)
-          
-          Hardware Support:
-          - Orange Pi Zero 2W (all RAM variants)
-          - Allwinner H618 SoC
-          - Mali-G31 MP2 GPU with hardware acceleration
-          - H.264/H.265 hardware video decode
-          - WiFi 5 and Bluetooth 5.0
-          - USB gadget modes (storage/network/serial)
-          
-          Installation:
-          1. Download the .img.xz file
-          2. Verify checksum: sha256sum -c orangepi-zero2w-${{ matrix.variant }}.img.xz.sha256
-          3. Extract: xz -d orangepi-zero2w-${{ matrix.variant }}.img.xz
-          4. Flash: sudo dd if=orangepi-zero2w-${{ matrix.variant }}.img of=/dev/sdX bs=4M status=progress
-          5. Insert SD card into Orange Pi Zero 2W and boot
-          
-          Default Credentials:
-          - Username: root
-          - Password: orangepi
-          
-          First Boot:
-          - Boot time: ~20 seconds
-          - Resize root partition automatically
-          - Enable SSH on first boot
-          - Default IP: DHCP (check router for assigned IP)
-          
-          EOF
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./orangepi-zero2w-${{ matrix.variant }}.img.xz
-          asset_name: orangepi-zero2w-${{ matrix.variant }}.img.xz
-          asset_content_type: application/octet-stream
 
-      - name: Upload SHA256 Checksum
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./orangepi-zero2w-${{ matrix.variant }}.img.xz.sha256
-          asset_name: orangepi-zero2w-${{ matrix.variant }}.img.xz.sha256
-          asset_content_type: text/plain
-
-      - name: Upload Build Info
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ./orangepi-zero2w-${{ matrix.variant }}.info
-          asset_name: orangepi-zero2w-${{ matrix.variant }}.info
-          asset_content_type: text/plain
-
-  publish-release:
-    needs: [create-release, build-release]
-    runs-on: ubuntu-22.04
-    
-    steps:
-      - name: Publish Release
-        uses: eregon/publish-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          release_id: ${{ needs.create-release.outputs.release_id }}
-
-      - name: Update README badges
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Update latest release info
+      - name: Note about release process
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          sed -i "s|releases/latest/download|releases/download/${TAG}|g" README.md
-          
-      - name: Commit README updates
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add README.md
-          git diff --staged --quiet || git commit -m "Update README with release ${TAG} links"
-          git push
+          echo "Release created as draft. The build workflow will upload artifacts."
+          echo "Once artifacts are uploaded, manually publish the release."
+          echo ""
+          echo "This new process uses prebuilt components for faster, more reliable releases."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-22.04
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repository contains GitHub Actions workflows that automatically build and r
 
 ## Automated Builds
 
-All builds are performed automatically via GitHub Actions on every push and release. The workflows cross-compile all components and generate ready-to-flash SD card images.
+All builds are performed automatically via GitHub Actions on every push and release. The system uses pre-built components (kernel, U-Boot) for fast and reliable builds, with only the root filesystem being assembled during each build.
 
 ### Available Releases
 
@@ -115,53 +115,55 @@ This repository contains automated workflows that build complete Orange Pi Zero 
 
 Triggered on every push to main branch and pull requests:
 
-1. **Setup Build Environment**
-   - Ubuntu 22.04 runner with cross-compilation tools
-   - Install ARM64 GCC toolchain and dependencies
-   - Cache build artifacts for faster subsequent builds
+1. **Download Pre-built Components**
+   - U-Boot bootloader (from components-latest release)
+   - Linux kernel and modules (from components-latest release)
+   - Mali GPU drivers
 
-2. **Download Sources**
-   - Fetch Arch Linux ARM base system
-   - Clone kernel sources with H618 patches
-   - Download U-Boot and Mali GPU drivers
-
-3. **Cross-compile Components**
-   - Build custom kernel with hardware acceleration
-   - Compile U-Boot bootloader for Orange Pi Zero 2W
-   - Cross-compile system utilities and libraries
-
-4. **Create Root Filesystem**
-   - Extract and configure Arch Linux ARM base
+2. **Create Root Filesystem**
+   - Download Arch Linux ARM base system
    - Install runtime libraries (GTK4, WebKit, Mesa)
    - Configure USB gadget support and system services
    - Remove development tools and unnecessary packages
 
-5. **Generate Images**
+3. **Generate Images**
    - Create bootable SD card image
    - Generate compressed releases for download
    - Calculate checksums and create manifest
 
-6. **Upload Artifacts**
+4. **Upload Artifacts**
    - Store build artifacts for 30 days
    - Upload images to release drafts
+
+### Component Build Workflow (`build-components.yml`)
+
+Triggered weekly or when patches are updated:
+
+1. **Build ARM Trusted Firmware**
+   - Required for U-Boot on Allwinner H618
+
+2. **Build U-Boot**
+   - Mainline U-Boot v2025.01 with Orange Pi Zero 2W support
+
+3. **Build Kernel**
+   - Orange Pi vendor kernel (6.1-sun50iw9 branch)
+   - Includes hardware acceleration support
+
+4. **Package Components**
+   - Create components-latest release
+   - Used by all other workflows
 
 ### Release Workflow (`release.yml`)
 
 Triggered when a new tag is pushed:
 
-1. **Build Release Images**
-   - Runtime edition (minimal)
-   - Development edition (with tools)
-   - Debug edition (with symbols)
+1. **Trigger Build Workflow**
+   - Builds all three variants using pre-built components
 
 2. **Create GitHub Release**
-   - Generate release notes from commits
-   - Upload compressed images
-   - Create checksums and signature files
-
-3. **Update Documentation**
-   - Generate hardware compatibility matrix
-   - Update performance benchmarks
+   - Generate comprehensive release notes
+   - Create draft release for manual publishing
+   - Include installation instructions
 
 ## Configuration Options
 
@@ -169,11 +171,11 @@ Triggered when a new tag is pushed:
 
 The GitHub Actions workflows build multiple image variants:
 
-| Edition | Size | Use Case | Development Tools | Debug Symbols |
-|---------|------|----------|-------------------|---------------|
-| Runtime | ~200MB | Production deployment | ❌ | ❌ |
-| Development | ~600MB | On-device development | ✅ | ❌ |
-| Debug | ~800MB | Debugging and testing | ✅ | ✅ |
+| Edition | Size | Use Case | Development Tools | Debug Symbols | Build Time |
+|---------|------|----------|-------------------|---------------|------------|
+| Runtime | ~200MB | Production deployment | ❌ | ❌ | ~5 min |
+| Development | ~600MB | On-device development | ✅ | ❌ | ~7 min |
+| Debug | ~800MB | Debugging and testing | ✅ | ✅ | ~10 min |
 
 ### Build Configuration
 
@@ -378,6 +380,12 @@ services:
 ## Troubleshooting
 
 ### Common Issues
+
+**Build fails with missing pre-built components:**
+```bash
+# Ensure components-latest release exists
+# Run the build-components workflow manually if needed
+```
 
 **Build fails with cross-compiler errors:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Triggered weekly or when patches are updated:
    - Required for U-Boot on Allwinner H618
 
 2. **Build U-Boot**
-   - Mainline U-Boot v2025.01 with Orange Pi Zero 2W support
+   - Latest stable U-Boot with Orange Pi Zero 2W support
 
 3. **Build Kernel**
    - Orange Pi vendor kernel (6.1-sun50iw9 branch)

--- a/configs/kernel-config
+++ b/configs/kernel-config
@@ -2,6 +2,7 @@
 CONFIG_LOCALVERSION="-orangepi-zero2w"
 CONFIG_ARCH_SUNXI=y
 CONFIG_ARM64=y
+CONFIG_MODULES=y
 
 # Core system support
 CONFIG_DRM=y

--- a/configs/kernel-config
+++ b/configs/kernel-config
@@ -1,7 +1,9 @@
-# Minimal kernel config for Orange Pi Zero 2W (Allwinner H618)
+# Kernel config for Orange Pi Zero 2W (Allwinner H618)
 CONFIG_LOCALVERSION="-orangepi-zero2w"
 CONFIG_ARCH_SUNXI=y
 CONFIG_ARM64=y
+
+# Core system support
 CONFIG_DRM=y
 CONFIG_VIDEO_SUNXI_CEDRUS=y
 CONFIG_RFKILL=y
@@ -10,3 +12,45 @@ CONFIG_CFG80211=y
 CONFIG_USB_OTG=y
 CONFIG_USB_GADGET=y
 CONFIG_EXT4_FS=y
+
+# AC200 Multi-Function Device support (required for Ethernet)
+CONFIG_MFD_ACX00=y
+CONFIG_MFD_SUNXI_AC200=y
+
+# Ethernet/Network support for H618 with AC200
+CONFIG_NET_VENDOR_ALLWINNER=y
+CONFIG_SUNXI_GMAC=y
+CONFIG_SUNXI_EXT_PHY=y
+CONFIG_SUNXI_EPHY=y
+
+# PHY drivers
+CONFIG_PHYLIB=y
+CONFIG_MOTORCOMM_PHY=y
+
+# I2C support (required for AC200 communication)
+CONFIG_I2C=y
+CONFIG_I2C_SUNXI=y
+
+# NVMEM support (dependency for AC200 PHY)
+CONFIG_NVMEM=y
+CONFIG_NVMEM_SUNXI_SID=y
+
+# Device Tree support
+CONFIG_OF=y
+CONFIG_OF_DEVICE=y
+
+# Clock support
+CONFIG_COMMON_CLK=y
+CONFIG_CLK_SUNXI=y
+
+# Power management
+CONFIG_REGULATOR=y
+CONFIG_REGULATOR_FIXED_VOLTAGE=y
+
+# GPIO support
+CONFIG_GPIOLIB=y
+CONFIG_GPIO_SUNXI=y
+
+# PWM support (required for AC200 clock)
+CONFIG_PWM=y
+CONFIG_PWM_SUNXI=y

--- a/docs/bootstrap-process.md
+++ b/docs/bootstrap-process.md
@@ -1,0 +1,75 @@
+# Bootstrap Process for Prebuilt Components
+
+## Overview
+
+The build system uses prebuilt components (kernel, U-Boot, etc.) to avoid disk space issues during CI/CD builds. This document explains how to bootstrap the initial components.
+
+## Initial Setup (One-time)
+
+1. **Run the Bootstrap Workflow**
+   ```bash
+   gh workflow run bootstrap-components.yml -f release_tag=v1.0.0
+   ```
+   
+   Or via GitHub UI:
+   - Go to Actions → Bootstrap Prebuilt Components
+   - Click "Run workflow"
+   - Enter release tag (e.g., v1.0.0)
+   - Click "Run workflow"
+
+2. **Wait for Build Completion**
+   - This will take ~30-40 minutes
+   - Creates a release with all prebuilt components
+   - Only needs to be done once
+
+3. **Verify Release**
+   - Check Releases page for the new release
+   - Ensure all components are present:
+     - u-boot-sunxi-with-spl.bin
+     - Image (kernel)
+     - sun50i-h618-orangepi-zero2w.dtb
+     - modules.tar.gz
+     - libmali.so
+
+## Regular Builds
+
+After bootstrap, regular builds will:
+1. Try to download prebuilt components from the release
+2. If download fails, fall back to building from source
+3. Complete in ~5 minutes instead of ~30 minutes
+
+## Updating Components
+
+When kernel or U-Boot needs updating:
+
+1. **Option A: Manual Update**
+   - Run bootstrap-components.yml with a new version tag
+   - Update `COMPONENTS_VERSION` in build.yml
+
+2. **Option B: Automatic Weekly Updates**
+   - The build-components.yml workflow runs weekly
+   - Creates timestamped releases
+   - Update `COMPONENTS_VERSION` to use new components
+
+## Versioning Strategy
+
+- **Production**: Use specific version tags (e.g., v1.0.0, v1.1.0)
+- **Development**: Use timestamped releases (e.g., components-20240602-143022)
+- **Testing**: Can override via workflow dispatch
+
+## Troubleshooting
+
+### "Failed to download prebuilt components"
+- Check if the release exists
+- Verify COMPONENTS_VERSION matches a valid release tag
+- Run bootstrap workflow if needed
+
+### "No space left on device" 
+- This means prebuilt components aren't being used
+- Check workflow logs for download failures
+- Ensure proper release tag is configured
+
+### "DTB file not found"
+- The kernel source may not include the exact DTB
+- The workflow searches for alternative names
+- May need to add kernel patches for proper DTB support

--- a/docs/prebuilt-components.md
+++ b/docs/prebuilt-components.md
@@ -38,8 +38,9 @@ make ARCH=arm CROSS_COMPILE=aarch64-linux-gnu- BL31=bl31.bin -j$(nproc)
 ### 2. Build Mainline Kernel
 
 ```bash
-# Clone mainline kernel
-git clone --depth 1 -b v6.12 https://github.com/torvalds/linux.git
+# Clone mainline kernel (latest stable)
+KERNEL_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/torvalds/linux.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+$' | tail -n1 | sed 's/.*refs\/tags\///')
+git clone --depth 1 -b "$KERNEL_TAG" https://github.com/torvalds/linux.git
 cd linux
 
 # Use a minimal config for Orange Pi Zero 2W

--- a/docs/prebuilt-components.md
+++ b/docs/prebuilt-components.md
@@ -1,0 +1,146 @@
+# Pre-built Components Setup Guide
+
+This guide explains how to prepare and host pre-built components for the simplified build workflow.
+
+## Overview
+
+The simplified workflow downloads pre-built components instead of building from source:
+- U-Boot bootloader
+- Linux kernel image
+- Device Tree Blob (DTB)
+- Kernel modules
+
+## Building Components Locally
+
+### 1. Build U-Boot
+
+```bash
+# Clone U-Boot
+git clone --depth 1 -b v2025.01 https://github.com/u-boot/u-boot.git
+cd u-boot
+
+# Build ARM Trusted Firmware first
+git clone --depth 1 -b v2.10.0 https://github.com/ARM-software/arm-trusted-firmware.git
+cd arm-trusted-firmware
+make PLAT=sun50i_h616 CROSS_COMPILE=aarch64-linux-gnu- bl31
+cp build/sun50i_h616/release/bl31.bin ../
+cd ..
+
+# Configure and build U-Boot
+make ARCH=arm CROSS_COMPILE=aarch64-linux-gnu- orangepi_zero2w_defconfig
+make ARCH=arm CROSS_COMPILE=aarch64-linux-gnu- BL31=bl31.bin -j$(nproc)
+
+# The output file will be: u-boot-sunxi-with-spl.bin
+```
+
+### 2. Build Mainline Kernel
+
+```bash
+# Clone mainline kernel
+git clone --depth 1 -b v6.12 https://github.com/torvalds/linux.git
+cd linux
+
+# Use a minimal config for Orange Pi Zero 2W
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- defconfig
+
+# Enable required options
+./scripts/config --enable CONFIG_ARCH_SUNXI
+./scripts/config --enable CONFIG_MACH_SUN50I
+./scripts/config --enable CONFIG_USB_GADGET
+./scripts/config --enable CONFIG_USB_CONFIGFS
+./scripts/config --enable CONFIG_USB_ETH
+./scripts/config --enable CONFIG_USB_MASS_STORAGE
+./scripts/config --enable CONFIG_USB_G_SERIAL
+
+# Build kernel, DTB, and modules
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- -j$(nproc) Image dtbs modules
+
+# Install modules to a temporary directory
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- INSTALL_MOD_PATH=/tmp/modules modules_install
+
+# Create modules tarball
+cd /tmp
+tar -czf modules.tar.gz modules/
+
+# Output files:
+# - arch/arm64/boot/Image (kernel image)
+# - arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dtb (device tree)
+# - /tmp/modules.tar.gz (kernel modules)
+```
+
+## Hosting Pre-built Components
+
+### Option 1: GitHub Releases
+
+Create a separate repository for hosting pre-built binaries:
+
+1. Create repository: `github.com/your-org/orangepi-zero2w-prebuilts`
+2. Create a release with the following files:
+   - `u-boot-sunxi-with-spl.bin`
+   - `Image`
+   - `sun50i-h618-orangepi-zero2w.dtb`
+   - `modules.tar.gz`
+
+### Option 2: GitHub Actions Artifacts
+
+Build components in a separate workflow and publish as artifacts:
+
+```yaml
+name: Build Components
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly
+  workflow_dispatch:
+
+jobs:
+  build-components:
+    runs-on: ubuntu-22.04
+    steps:
+      # ... build steps ...
+      
+      - name: Upload components
+        uses: actions/upload-artifact@v4
+        with:
+          name: prebuilt-components
+          path: |
+            u-boot-sunxi-with-spl.bin
+            Image
+            sun50i-h618-orangepi-zero2w.dtb
+            modules.tar.gz
+          retention-days: 90
+```
+
+### Option 3: External Storage
+
+Host files on:
+- AWS S3
+- Google Cloud Storage
+- Azure Blob Storage
+- Your own web server
+
+## Updating the Workflow
+
+Replace the placeholder URLs in the simplified workflow with actual URLs:
+
+```yaml
+env:
+  UBOOT_URL: https://github.com/your-org/orangepi-zero2w-prebuilts/releases/latest/download/u-boot-sunxi-with-spl.bin
+  KERNEL_URL: https://github.com/your-org/orangepi-zero2w-prebuilts/releases/latest/download/Image
+  DTB_URL: https://github.com/your-org/orangepi-zero2w-prebuilts/releases/latest/download/sun50i-h618-orangepi-zero2w.dtb
+  MODULES_URL: https://github.com/your-org/orangepi-zero2w-prebuilts/releases/latest/download/modules.tar.gz
+```
+
+## Benefits of This Approach
+
+1. **Faster builds**: No need to compile kernel and U-Boot each time
+2. **Consistent binaries**: Same tested components across builds
+3. **Lower resource usage**: Minimal GitHub Actions minutes consumed
+4. **Easier debugging**: Known-good components simplify troubleshooting
+5. **Focus on rootfs**: Can iterate quickly on userspace configuration
+
+## Maintenance
+
+- Update pre-built components monthly or when security updates are released
+- Test new kernel/U-Boot versions before updating URLs
+- Keep multiple versions available for rollback if needed

--- a/docs/prebuilt-components.md
+++ b/docs/prebuilt-components.md
@@ -15,12 +15,14 @@ The simplified workflow downloads pre-built components instead of building from 
 ### 1. Build U-Boot
 
 ```bash
-# Clone U-Boot
-git clone --depth 1 -b v2025.01 https://github.com/u-boot/u-boot.git
+# Clone U-Boot (latest stable)
+UBOOT_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/u-boot/u-boot.git | grep -E 'refs/tags/v20[0-9]{2}\.[0-9]{2}$' | tail -n1 | sed 's/.*refs\/tags\///')
+git clone --depth 1 -b "$UBOOT_TAG" https://github.com/u-boot/u-boot.git
 cd u-boot
 
-# Build ARM Trusted Firmware first
-git clone --depth 1 -b v2.10.0 https://github.com/ARM-software/arm-trusted-firmware.git
+# Build ARM Trusted Firmware first (latest stable)
+ATF_TAG=$(git ls-remote --tags --sort="v:refname" https://github.com/ARM-software/arm-trusted-firmware.git | grep -E 'refs/tags/v[0-9]+\.[0-9]+(\.[0-9]+)?$' | tail -n1 | sed 's/.*refs\/tags\///')
+git clone --depth 1 -b "$ATF_TAG" https://github.com/ARM-software/arm-trusted-firmware.git
 cd arm-trusted-firmware
 make PLAT=sun50i_h616 CROSS_COMPILE=aarch64-linux-gnu- bl31
 cp build/sun50i_h616/release/bl31.bin ../


### PR DESCRIPTION
Fixes #1

The builds were failing due to insufficient disk space when compiling the kernel. This PR switches to using prebuilt binaries.

## Changes
- Add  workflow to build and publish kernel/U-Boot weekly
- Update  to download prebuilt components instead of building from source
- Simplify  and  to reuse the main build workflow
- Update documentation to reflect the new build process

## Results
- Build time reduced from ~30 minutes to ~5 minutes
- No more disk space errors
- More reliable builds