### PR TITLE
Fix rootfs extraction permission errors in build scripts

### DIFF
--- a/scripts/create-image.sh
+++ b/scripts/create-image.sh
@@ -75,35 +75,35 @@ echo "Image size: ${IMAGE_SIZE}MB (boot: ${BOOT_SIZE}MB, rootfs: ${ROOTFS_SIZE}M
 dd if=/dev/zero of="$OUTPUT" bs=1M count="$IMAGE_SIZE" status=progress
 
 # Set up loop device
-LOOP_DEV=$(losetup -f --show "$OUTPUT")
+LOOP_DEV=$(sudo losetup -f --show "$OUTPUT")
 echo "Using loop device: $LOOP_DEV"
 
 # Create partition table
-parted -s "$LOOP_DEV" mklabel msdos
-parted -s "$LOOP_DEV" mkpart primary fat32 1MiB "$((BOOT_SIZE + 1))"MiB
-parted -s "$LOOP_DEV" mkpart primary ext4 "$((BOOT_SIZE + 1))"MiB 100%
-parted -s "$LOOP_DEV" set 1 boot on
+sudo parted -s "$LOOP_DEV" mklabel msdos
+sudo parted -s "$LOOP_DEV" mkpart primary fat32 1MiB "$((BOOT_SIZE + 1))"MiB
+sudo parted -s "$LOOP_DEV" mkpart primary ext4 "$((BOOT_SIZE + 1))"MiB 100%
+sudo parted -s "$LOOP_DEV" set 1 boot on
 
 # Get partition devices
 BOOT_DEV="${LOOP_DEV}p1"
 ROOTFS_DEV="${LOOP_DEV}p2"
 
 # Format partitions
-mkfs.vfat -F 32 -n "BOOT" "$BOOT_DEV"
-mkfs.ext4 -L "rootfs" "$ROOTFS_DEV"
+sudo mkfs.vfat -F 32 -n "BOOT" "$BOOT_DEV"
+sudo mkfs.ext4 -L "rootfs" "$ROOTFS_DEV"
 
 # Mount partitions
 BOOT_MNT=$(mktemp -d)
 ROOTFS_MNT=$(mktemp -d)
-mount "$BOOT_DEV" "$BOOT_MNT"
-mount "$ROOTFS_DEV" "$ROOTFS_MNT"
+sudo mount "$BOOT_DEV" "$BOOT_MNT"
+sudo mount "$ROOTFS_DEV" "$ROOTFS_MNT"
 
 # Install U-Boot
-dd if="$UBOOT" of="$LOOP_DEV" bs=1024 seek=8 conv=notrunc
+sudo dd if="$UBOOT" of="$LOOP_DEV" bs=1024 seek=8 conv=notrunc
 
 # Copy boot files
-mkdir -p "$BOOT_MNT/extlinux"
-cat > "$BOOT_MNT/extlinux/extlinux.conf" << EOF
+sudo mkdir -p "$BOOT_MNT/extlinux"
+sudo tee "$BOOT_MNT/extlinux/extlinux.conf" > /dev/null << EOF
 DEFAULT orangepi
 LABEL orangepi
   LINUX /Image
@@ -111,22 +111,22 @@ LABEL orangepi
   APPEND root=/dev/mmcblk0p2 rw rootwait console=ttyS0,115200 quiet
 EOF
 
-cp "$KERNEL" "$BOOT_MNT/Image"
-mkdir -p "$BOOT_MNT/dtb/allwinner"
-cp "$DTB" "$BOOT_MNT/dtb/allwinner/"
+sudo cp "$KERNEL" "$BOOT_MNT/Image"
+sudo mkdir -p "$BOOT_MNT/dtb/allwinner"
+sudo cp "$DTB" "$BOOT_MNT/dtb/allwinner/"
 
 # Copy rootfs files
-rsync -aHAXx "$ROOTFS"/ "$ROOTFS_MNT"/
+sudo rsync -aHAXx "$ROOTFS"/ "$ROOTFS_MNT"/
 
 # Create gadget mode setting file
-echo "network" > "$BOOT_MNT/gadget-mode"
+echo "network" | sudo tee "$BOOT_MNT/gadget-mode" > /dev/null
 
 # Unmount and clean up
 sync
-umount "$BOOT_MNT"
-umount "$ROOTFS_MNT"
+sudo umount "$BOOT_MNT"
+sudo umount "$ROOTFS_MNT"
 rmdir "$BOOT_MNT"
 rmdir "$ROOTFS_MNT"
-losetup -d "$LOOP_DEV"
+sudo losetup -d "$LOOP_DEV"
 
 echo "Image created successfully: $OUTPUT"

--- a/scripts/create-rootfs.sh
+++ b/scripts/create-rootfs.sh
@@ -51,33 +51,33 @@ DEVELOPMENT_PACKAGES="$RUNTIME_PACKAGES git gcc make cmake go"
 DEBUG_PACKAGES="$DEVELOPMENT_PACKAGES gdb valgrind strace perf"
 
 # Create clean output directory
-rm -rf "$OUTPUT"
-mkdir -p "$OUTPUT"
+sudo rm -rf "$OUTPUT"
+sudo mkdir -p "$OUTPUT"
 
 echo "Creating root filesystem for variant: $VARIANT"
 
 # Extract base system
 echo "Extracting Arch Linux ARM base system..."
-tar -xf "$ARCH_TARBALL" -C "$OUTPUT"
+sudo tar -xf "$ARCH_TARBALL" -C "$OUTPUT"
 
 # Install kernel modules
 echo "Installing kernel modules..."
-mkdir -p "$OUTPUT/lib/modules"
-cp -a "$KERNEL_MODULES/lib/modules/"* "$OUTPUT/lib/modules/"
+sudo mkdir -p "$OUTPUT/lib/modules"
+sudo cp -a "$KERNEL_MODULES/lib/modules/"* "$OUTPUT/lib/modules/"
 
 # Install Mali GPU driver
 echo "Installing Mali GPU driver..."
-mkdir -p "$OUTPUT/usr/lib"
-cp "$MALI_DRIVER" "$OUTPUT/usr/lib/libmali.so"
-ln -sf libmali.so "$OUTPUT/usr/lib/libEGL.so.1"
-ln -sf libmali.so "$OUTPUT/usr/lib/libGLESv2.so.2"
-ln -sf libmali.so "$OUTPUT/usr/lib/libgbm.so.1"
+sudo mkdir -p "$OUTPUT/usr/lib"
+sudo cp "$MALI_DRIVER" "$OUTPUT/usr/lib/libmali.so"
+sudo ln -sf libmali.so "$OUTPUT/usr/lib/libEGL.so.1"
+sudo ln -sf libmali.so "$OUTPUT/usr/lib/libGLESv2.so.2"
+sudo ln -sf libmali.so "$OUTPUT/usr/lib/libgbm.so.1"
 
 # Create necessary configuration based on variant
-mkdir -p "$OUTPUT/etc/systemd/system/multi-user.target.wants"
+sudo mkdir -p "$OUTPUT/etc/systemd/system/multi-user.target.wants"
 
 # Create USB gadget service
-cat > "$OUTPUT/etc/systemd/system/usb-gadget.service" << EOF
+sudo tee "$OUTPUT/etc/systemd/system/usb-gadget.service" > /dev/null << EOF
 [Unit]
 Description=USB Gadget Mode Setup
 After=local-fs.target
@@ -91,11 +91,11 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 EOF
 
-ln -sf ../usb-gadget.service "$OUTPUT/etc/systemd/system/multi-user.target.wants/usb-gadget.service"
+sudo ln -sf ../usb-gadget.service "$OUTPUT/etc/systemd/system/multi-user.target.wants/usb-gadget.service"
 
 # Create gadget setup script
-mkdir -p "$OUTPUT/usr/local/bin"
-cat > "$OUTPUT/usr/local/bin/setup-gadget.sh" << EOF
+sudo mkdir -p "$OUTPUT/usr/local/bin"
+sudo tee "$OUTPUT/usr/local/bin/setup-gadget.sh" > /dev/null << EOF
 #!/bin/bash
 # Script to set up USB gadget mode based on /boot/gadget-mode
 
@@ -122,10 +122,10 @@ if [ -f /boot/gadget-mode ]; then
 fi
 EOF
 
-chmod +x "$OUTPUT/usr/local/bin/setup-gadget.sh"
+sudo chmod +x "$OUTPUT/usr/local/bin/setup-gadget.sh"
 
 # Create first boot setup
-cat > "$OUTPUT/etc/systemd/system/firstboot.service" << EOF
+sudo tee "$OUTPUT/etc/systemd/system/firstboot.service" > /dev/null << EOF
 [Unit]
 Description=First Boot Setup
 After=local-fs.target
@@ -141,9 +141,9 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 EOF
 
-ln -sf ../firstboot.service "$OUTPUT/etc/systemd/system/multi-user.target.wants/firstboot.service"
+sudo ln -sf ../firstboot.service "$OUTPUT/etc/systemd/system/multi-user.target.wants/firstboot.service"
 
-cat > "$OUTPUT/usr/local/bin/firstboot.sh" << EOF
+sudo tee "$OUTPUT/usr/local/bin/firstboot.sh" > /dev/null << EOF
 #!/bin/bash
 # First boot setup script
 
@@ -159,18 +159,18 @@ ssh-keygen -A
 echo "orangepi-zero2w" > /etc/hostname
 EOF
 
-chmod +x "$OUTPUT/usr/local/bin/firstboot.sh"
+sudo chmod +x "$OUTPUT/usr/local/bin/firstboot.sh"
 
 # Set root password
 echo "Setting root password..."
-echo 'root:orangepi' | chroot "$OUTPUT" chpasswd
+echo 'root:orangepi' | sudo chroot "$OUTPUT" chpasswd
 
 # Clean up based on variant
 if [ "$VARIANT" = "runtime" ]; then
   echo "Cleaning up for runtime edition..."
-  rm -rf "$OUTPUT/usr/include"
-  rm -rf "$OUTPUT/usr/share/man"
-  rm -rf "$OUTPUT/usr/share/doc"
+  sudo rm -rf "$OUTPUT/usr/include"
+  sudo rm -rf "$OUTPUT/usr/share/man"
+  sudo rm -rf "$OUTPUT/usr/share/doc"
 fi
 
 echo "Root filesystem created successfully at: $OUTPUT"


### PR DESCRIPTION
## Summary
- Add sudo privileges to all file operations that handle the root filesystem in build scripts
- Fixes CI/CD workflow failures during rootfs extraction step

## Test plan
- [ ] Verify build-components.yml workflow completes successfully
- [ ] Verify build.yml workflow can create images without permission errors
- [ ] Confirm generated images are functional

Fixes #5